### PR TITLE
Show delete button to current user only

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -139,7 +139,7 @@
         <%= link_to project.project_url do %>
           <p><%= project.title.upcase %><p>
           <p><%= project.description %></p>
-          <% if current_user %>
+          <% if current_user?(@user) %>
             <%= link_to "Delete", project_path(project.id), method: :delete, class: "del-btn" %>
           <% end %>
       </div>


### PR DESCRIPTION
Anh, this commit ensures that the delete button for projects is only shown to the project owners. It will hide the delete button on other users' pages and prevent people from deleting projects that are not their own. 
